### PR TITLE
Add pyproject.toml to allow for installation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.pyc
 *.sav
+build/
+xyppy.egg-info/

--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ### Usage:
 
-* python -m xyppy &lt;FILE\_OR\_URL&gt; (in module/dev mode)
-* python xyppy.py &lt;FILE\_OR\_URL&gt; (in single file mode)
-* run ./build-single-file-version.py to get that handy single-file xyppy.py
+* `python -m xyppy &lt;FILE\_OR\_URL&gt;` (in module/dev mode)
+* `python xyppy.py &lt;FILE\_OR\_URL&gt;` (in single file mode)
+* run `./build-single-file-version.py` to get that handy single-file xyppy.py
+* `python -m pip install` . to install the module
 
 ### Quick Look:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "xyppy"
+version = "0.0.0"
+authors = [
+  { name="theinternetftw" },
+]
+description = "Play Z-machine text adventure games"
+readme = "README.md"
+requires-python = ">=3.8"
+classifiers = [
+	"Programming Language :: Python :: 3",
+	"License :: OSI Approved :: MIT License",
+	"Operating System :: OS Independent",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console :: Curses",
+    "Topic :: Games/Entertainment",
+    
+]
+keywords = ["infocom", "adventure", "game", "z-machine", "zmachine"]
+dependencies = [
+    # none
+]
+[project.urls]
+Homepage = "https://github.com/theinternetftw/xyppy"
+Repository = "https://github.com/theinternetftw/xyppy.git"
+Issues = "https://github.com/theinternetftw/issues"
+
+[build-system]
+requires = [
+	"setuptools>=61.0",
+]
+build_backend="setuptools.build_meta"
+
+[tool.setuptools]
+packages = [
+    "xyppy",
+]


### PR DESCRIPTION
Added pyproject.toml. Installation is now possible with

     pip install .

README.md updated to explain this. .gitignore updated to ignore build directories.